### PR TITLE
Ensure copying of firmware directories

### DIFF
--- a/scripts/setup/sound/sound.sh
+++ b/scripts/setup/sound/sound.sh
@@ -2,9 +2,9 @@
 
 # 1. Copy firmware
 if [ -d "/lib/firmware" ]; then
-  sudo cp ../../../firmware/* /lib/firmware
+  sudo cp -r ../../../firmware/* /lib/firmware
 elif [ -d "/usr/lib/firmware" ]; then
-  sudo cp ../../../firmware/* /usr/lib/firmware
+  sudo cp -r ../../../firmware/* /usr/lib/firmware
 else
   echo "Could not find firmware directory, skipping firmware install"
 fi


### PR DESCRIPTION
The following output occurs upon executing `sound.sh`:
<pre>
<b>cp: omitting directory ‘../../../firmware/intel’</b>
Setting sound card UCM verb
Restoring asla config
alsactl: set_control:1461: Cannot write control '2:0:0:IEC958 Playback Default:0' : Operation not permitted
alsactl: set_control:1461: Cannot write control '3:3:0:Playback Channel Map:0' : Device or resource busy
Sound setup completed successfully.
</pre>

I suspect people haven't found issue with this since they either have the file copied over from a previous setup, or their distro's `linux-firmware(-nonfree)` package has supplied it.