### PR TITLE
Use EC device name instead of ID to identify whether lightbar attributes should appear

### DIFF
--- a/scripts/apply_patch.sh
+++ b/scripts/apply_patch.sh
@@ -33,8 +33,16 @@ mv sound/soc/intel/sst-debugfs.* sound/soc/intel/common
 ln -s $DIR/config .config
 
 # Apply custom patches
-echo -- Applying custom patch --
+echo -- Applying custom patch: monkey.patch --
 patch -p1 < $DIR/monkey.patch
+if [ $? -ne 0 ]; then
+  echo Something wrong happened...
+  echo I couldn\'t patch the main tree with the custom patch which means that changes upstream require an update to this script.
+  exit 1
+fi
+
+echo -- Applying custom patch: lightbar-sys-attributes.patch --
+patch -p1 < $DIR/lightbar-sys-attributes.patch
 if [ $? -ne 0 ]; then
   echo Something wrong happened...
   echo I couldn\'t patch the main tree with the custom patch which means that changes upstream require an update to this script.

--- a/scripts/lightbar-sys-attributes.patch
+++ b/scripts/lightbar-sys-attributes.patch
@@ -1,0 +1,30 @@
+From 777d8c9cb33e4b3ef558e19e3b88c1e3c579b484 Mon Sep 17 00:00:00 2001
+From: Clinton Sprain <clinton.sprain@gmail.com>
+Date: Thu, 3 Mar 2016 07:50:43 -0600
+Subject: [PATCH 1/1] Use EC device name instead of ID to identify whether lightbar attributes should appear.
+
+---
+ build/linux/drivers/platform/chrome/cros_ec_lightbar.c | 7 ++++++-
+ 1 file changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/build/linux/drivers/platform/chrome/cros_ec_lightbar.c b/build/linux/drivers/platform/chrome/cros_ec_lightbar.c
+index ff76405..b6356b3 100644
+--- linux-patched/drivers/platform/chrome/cros_ec_lightbar.c
++++ b/build/linux/drivers/platform/chrome/cros_ec_lightbar.c
+@@ -414,7 +414,12 @@ static umode_t cros_ec_lightbar_attrs_are_visible(struct kobject *kobj,
+ 					      struct cros_ec_dev, class_dev);
+ 	struct platform_device *pdev = container_of(ec->dev,
+ 						   struct platform_device, dev);
+-	if (pdev->id != 0)
++	struct cros_ec_platform *pdata = pdev->dev.platform_data;
++	int is_cros_ec;
++
++	is_cros_ec = strcmp(pdata->ec_name, CROS_EC_DEV_NAME);
++
++	if (is_cros_ec != 0)
+ 		return 0;
+ 
+ 	/* Only instantiate this stuff if the EC has a lightbar */
+-- 
+2.5.0
+


### PR DESCRIPTION
Address #119, allowing the lightbar attributes (brightness, interval_msec, led_rgb, sequence, version) to appear in the lightbar directory under /sys.

Tested in Ubuntu: patch with build.sh, compile/install the kernel, reboot and verify the attributes above are visible in the following places:

`/sys/devices/platform/cros_ec_lpc.0/cros-ec-ctl.*.auto/chromeos/cros_ec/lightbar/`
(where * is the first ID, almost always 1 but occasionally not; there will be two of these, and the second has cros_pd instead of cros_ec), and
`/sys/class/chromeos/cros_ec/lightbar/`
(where cros_ec here is a symlink to the cros_ec in the first path). You can then mess around with the lightbar by echoing commands at them.
```
sudo chmod 666 *  # make them read/write for non-root users
echo stop > sequence  # prevent lightbar from automatically resetting itself to Chrome colors
echo 0 225 240 255 1 128 170 200 2 64 100 130 3 32 40 70 > led_rgb  # set lightbar to Chromium colors
```
Messing with it this way on a regular basis probably could benefit from some init scripts to automatically stop the sequence and modify the lightbar upon boot/wake, and automatically reset and start the sequence on the lightbar prior to sleep - otherwise it doesn't go to sleep along with the rest of the computer. Might be a bit outside the scope of your project though. :)