### PR TITLE
Clone with --depth=1 because the repo is huge.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Ubuntu, Debian or Arch Linux.
 ### Ubuntu / Debian
 
 ``` bash
-$ git clone https://github.com/raphael/linux-samus
+$ git clone --depth=1 https://github.com/raphael/linux-samus
 $ cd linux-samus/build/debian
 $ sudo dpkg -i *.deb
 ```
@@ -43,7 +43,7 @@ yaourt -S linux-samus4
 The entire kernel patched tree is located under `build/linux`, compile and install using the usual
 instructions for installing kernels. For example:
 ``` bash
-$ git clone https://github.com/raphael/linux-samus
+$ git clone --depth=1 https://github.com/raphael/linux-samus
 $ cd linux-samus/build/linux
 $ make nconfig
 $ make -j4


### PR DESCRIPTION
Change a few `git clone` lines in the README to use `--depth=1` because the repo is huge. This reduces the clone size to ~200mb for me.

`--depth=1` just makes git only get the history for each line one commit deep. I don't think most people cloning the repo need all the history. If they do they probably know how to get it.