### PR TITLE
Parallel compilation

### DIFF
--- a/scripts/archlinux/PKGBUILD
+++ b/scripts/archlinux/PKGBUILD
@@ -32,7 +32,7 @@ prepare() {
 
 build() {
   cd "${srcdir}/${_srcname}"
-  CFLAGS+=" -march=broadwell" make bzImage modules
+  CFLAGS+=" -march=broadwell" make -j2 bzImage modules
 }
 
 _package() {

--- a/scripts/archlinux/PKGBUILD
+++ b/scripts/archlinux/PKGBUILD
@@ -32,7 +32,7 @@ prepare() {
 
 build() {
   cd "${srcdir}/${_srcname}"
-  CFLAGS+=" -march=broadwell" make -j2 bzImage modules
+  CFLAGS+=" -march=broadwell" make -j4 bzImage modules
 }
 
 _package() {


### PR DESCRIPTION
Cut down build time - the hardware has two real CPU cores, make use of them.