### PR TITLE
Allow overlayfs to be mounted from unprivileged user namespaces

### DIFF
--- a/build/linux/fs/overlayfs/super.c
+++ b/build/linux/fs/overlayfs/super.c
@@ -1380,6 +1380,7 @@ static struct file_system_type ovl_fs_type = {
 	.name		= "overlay",
 	.mount		= ovl_mount,
 	.kill_sb	= kill_anon_super,
+	.fs_flags	= FS_USERNS_MOUNT,
 };
 MODULE_ALIAS_FS("overlay");
 


### PR DESCRIPTION
In upstream Linux, unprivileged user namespaces aren't allowed to mount overlay filesystems.  But for several years Ubuntu has carried a [local kernel patch](https://git.launchpad.net/~ubuntu-kernel/ubuntu/+source/linux/+git/vivid/commit/?id=78ec4549) that allows it, and some container use cases (e.g. certain LXC configurations or [vpnns](https://github.com/cernekee/ocproxy#vpnns-experimental)) depend on this capability.  AIUI some other distributions, such as SUSE, also apply this change.

This patch adds it back to the samus kernel.

Full disclosure: there have been a number of security holes related to overlayfs + namespaces.  Omitting this patch might improve security relative to the stock Ubuntu kernels, at the expense of breaking some functionality.